### PR TITLE
Bug fixed missing query daily account billing

### DIFF
--- a/src/Models/QueryAccountBillRequest.php
+++ b/src/Models/QueryAccountBillRequest.php
@@ -39,6 +39,16 @@ class QueryAccountBillRequest extends Model
     public $productCode;
 
     /**
+     * @var string
+     */
+    public $billingDate;
+
+    /**
+     * @var string
+     */
+    public $granularity;
+
+    /**
      * @var int
      */
     public $billOwnerId;
@@ -50,6 +60,8 @@ class QueryAccountBillRequest extends Model
         'isGroupByProduct' => 'IsGroupByProduct',
         'productCode'      => 'ProductCode',
         'billOwnerId'      => 'BillOwnerId',
+        'billingDate'      => 'BillingDate',
+        'granularity'      => 'Granularity'
     ];
 
     public function validate()
@@ -79,6 +91,12 @@ class QueryAccountBillRequest extends Model
         }
         if (null !== $this->billOwnerId) {
             $res['BillOwnerId'] = $this->billOwnerId;
+        }
+        if (null !== $this->billingDate) {
+            $res['BillingDate'] = $this->billingDate;
+        }
+        if (null !== $this->granularity) {
+            $res['Granularity'] = $this->granularity;
         }
 
         return $res;
@@ -112,6 +130,12 @@ class QueryAccountBillRequest extends Model
         }
         if (isset($map['BillOwnerId'])) {
             $model->billOwnerId = $map['BillOwnerId'];
+        }
+        if (isset($map['BillingDate'])) {
+            $model->billOwnerId = $map['BillingDate'];
+        }
+        if (isset($map['Granularity'])) {
+            $model->billOwnerId = $map['Granularity'];
         }
 
         return $model;


### PR DESCRIPTION
When using QueryAccountBill (账号账单查询服务) api in php sdk, it's seems like missing two parameters billingDate and granularity. Because of that, every api all will be the monthly api call instead of daily api call. 

There is a quick fixed of that. I'm not sure this side effect of this quick fixed when force to change value in this file. Because some caution said we can't edit this file. Maybe there is someway generate this file. I don't know it but i fixed it and work like a charm
```
"// This file is auto-generated, don't edit it. Thanks."
```

https://next.api.alibabacloud.com/api/BssOpenApi/2017-12-14/QueryAccountBill


![image](https://user-images.githubusercontent.com/8490834/127469355-6afafc5f-779b-4c7d-9ee0-d5e7881a6e66.png)

@sdk-team 